### PR TITLE
fix(index): It's specified that the catch error is an Error

### DIFF
--- a/BackEnd/index.ts
+++ b/BackEnd/index.ts
@@ -8,6 +8,6 @@ sequelize
     console.log("Database synced correctly");
     server.listen(PORT, () => console.log("Server listening on port " + PORT));
   })
-  .catch((error) => {
+  .catch((error:Error) => {
     console.error(error);
   });


### PR DESCRIPTION
It's specified that the catch error is an Error so that TypeScript understands it and doesn't mark it as a syntax error