### PR TITLE
feat(getPreset): Added functionality to get all presets, including pa…

### DIFF
--- a/src/controllers/preset/getPresetController.ts
+++ b/src/controllers/preset/getPresetController.ts
@@ -1,16 +1,53 @@
 import { Request, Response } from "express";
 import getPresetHandler from "../../handlers/preset/getPresetHandler";
 
+enum OrderType {
+  NAME = "name",
+  PRICE = "price",
+  PURCHASED = "purchased",
+  RATING = "rating",
+  RELEASE = "release",
+}
+
+enum OrderPriority {
+  ASC = "a",
+  DESC = "d",
+}
+
+enum PresetTypes {
+  ABOUT = "about",
+  HOME = "home",
+  FORM = "form",
+  CARD = "card",
+}
+enum PresetCategories {
+  BASIC = "basic",
+  MEDIUM = "medium",
+  PREMIUM = "premium",
+}
+
+interface Preset {
+  page?: number;
+  quantity?: number;
+  orderType?: OrderType;
+  orderPriority?: OrderPriority;
+  filters?: string;
+}
+
 const getPresetController = async (
   req: Request,
   res: Response
 ): Promise<void> => {
   try {
-    interface Preset {
-      id?: number;
-    }
-    const { id }: Preset = req.query;
-    const presets = await getPresetHandler(id);
+    const { page, quantity, orderType, orderPriority, filters }: Preset =
+      req.query;
+    const presets = await getPresetHandler({
+      page,
+      quantity,
+      orderType,
+      orderPriority,
+      filters,
+    });
     res.status(200).json(presets);
   } catch (error) {
     res.status(500).json({ error: (error as Error).message });

--- a/src/controllers/preset/getPresetController.ts
+++ b/src/controllers/preset/getPresetController.ts
@@ -14,18 +14,6 @@ enum OrderPriority {
   DESC = "d",
 }
 
-enum PresetTypes {
-  ABOUT = "about",
-  HOME = "home",
-  FORM = "form",
-  CARD = "card",
-}
-enum PresetCategories {
-  BASIC = "basic",
-  MEDIUM = "medium",
-  PREMIUM = "premium",
-}
-
 interface Preset {
   page?: number;
   quantity?: number;

--- a/src/handlers/preset/getPresetHandler.ts
+++ b/src/handlers/preset/getPresetHandler.ts
@@ -1,3 +1,141 @@
-const getPresetHandler = async (id: number | undefined) => {};
+import { Model } from "sequelize";
+import { Preset, UserPreset } from "../../db";
+
+enum PresetTypes {
+  ABOUT = "about",
+  HOME = "home",
+  FORM = "form",
+  CARD = "card",
+}
+enum PresetCategories {
+  BASIC = "basic",
+  MEDIUM = "medium",
+  PREMIUM = "premium",
+}
+
+enum OrderType {
+  NAME = "name",
+  PRICE = "price",
+  PURCHASED = "purchased",
+  RATING = "rating",
+  RELEASE = "release",
+}
+
+enum OrderPriority {
+  ASC = "a",
+  DESC = "d",
+}
+
+interface Review {
+  message?: string;
+  rating?: number;
+}
+
+interface Filter {
+  type?: PresetTypes;
+  category?: PresetCategories;
+  defaultColor?: string;
+}
+
+interface Params {
+  page?: number;
+  quantity?: number;
+  orderType?: OrderType;
+  orderPriority?: OrderPriority;
+  filters?: string;
+}
+
+const getPresetHandler = async ({
+  page = 1,
+  quantity = 10,
+  orderType = OrderType.RATING,
+  orderPriority = OrderPriority.DESC,
+  filters,
+}: Params) => {
+  const parsedFilters: Filter = filters ? JSON.parse(filters) : {};
+  const filteredPresets = await Preset.findAll({ where: { ...parsedFilters } });
+
+  const getReviews = async (preset: Model) => {
+    const userPresets = await UserPreset.findAll({
+      where: { presetId: preset.dataValues.id },
+    });
+    const reviews: Review[] = userPresets.map((userPreset) => {
+      const reviews = userPreset.dataValues.reviews;
+      return {
+        message: reviews.dataValues.message,
+        rating: reviews.dataValues.rating,
+      };
+    });
+    return reviews;
+  };
+
+  const calculateAverageRatings = async (presets: Model[]) => {
+    const avgRatings: Record<number, number> = {};
+
+    await Promise.all(
+      presets.map(async (preset) => {
+        const reviews = await getReviews(preset);
+        if (!reviews.length) return 0;
+        const totalRatings = reviews.reduce(
+          (sum, review) => sum + review.rating,
+          0
+        );
+        avgRatings[preset.dataValues.id] = totalRatings / reviews.length;
+      })
+    );
+
+    return avgRatings;
+  };
+  const averageRatings = await calculateAverageRatings(filteredPresets);
+
+  const sortingFunction = (a: Model, b: Model) => {
+    const sortOrder = orderPriority === OrderPriority.ASC ? 1 : -1;
+
+    switch (orderType) {
+      case OrderType.NAME:
+        return sortOrder * a.dataValues.name.localeCompare(b.dataValues.name);
+      case OrderType.PRICE:
+        return sortOrder * (a.dataValues.price - b.dataValues.price);
+      case OrderType.PURCHASED:
+        const purchasedA = a.dataValues.users ? a.dataValues.users.length : 0;
+        const purchasedB = b.dataValues.users ? b.dataValues.users.length : 0;
+        return sortOrder * (purchasedA - purchasedB);
+      case OrderType.RELEASE:
+        const dateA = new Date(a.dataValues.createdAt).getTime();
+        const dateB = new Date(b.dataValues.createdAt).getTime();
+        return sortOrder * (dateA - dateB);
+      case OrderType.RATING:
+        const avgRatingA = averageRatings[a.dataValues.id];
+        const avgRatingB = averageRatings[b.dataValues.id];
+        return sortOrder * (avgRatingA - avgRatingB);
+      default:
+        return 0;
+    }
+  };
+  const orderedPresets = filteredPresets.sort(sortingFunction);
+
+  const presets = await Promise.all(
+    orderedPresets.map(async (preset) => {
+      const { dataValues: data } = preset;
+      const reviews = await getReviews(preset);
+      const ratingAverage = await calculateAverageRatings([preset]);
+
+      return {
+        id: data.id,
+        name: data.name,
+        price: data.price,
+        color: data.defaultColor,
+        type: data.type,
+        category: data.category,
+        reviews,
+        ratingAverage: ratingAverage[data.id],
+        purchased: data.users ? data.users.length : 0,
+        isDisabled: data.isDisabled,
+        release: data.createdAt,
+      };
+    })
+  );
+  return presets.slice(page * quantity - quantity, page * quantity);
+};
 
 export default getPresetHandler;


### PR DESCRIPTION
## Get presets
Added functionality to get all presets following certain parameters

## Usage
All information is received via query
### Pages
Get a specific page from the preset list, each page contains the specified amount of presets per page. Page 1 by default
```javascript
const chosenPage = 1;
const presets = await axios.get(`${baseURL}/?page=${chosenPage}`) // This would return the first page of presets
```
### Quantity
Specifies the amount of presets per page, 10 presets by default
```javascript
const presetsPerPage= 5;
const presets1 = await axios.get(`${baseURL}/?quantity=${presetsPerPage}`) // This would return 5 presets per page
const presets2 = await axios.get(`${baseURL}/`) // This would return 10 presets per page
```
### Order type and priority
Order all presets requested based on a property (rating by default), also choose whether it's ascendant or descendant (descendant by default)
```javascript
const presets1 = await axios.get(`${baseURL}/?orderType=name&orderPriority=a`) // This would order presets by name alphabetically
const presets2 = await axios.get(`${baseURL}/?orderType=price`) // This would order presets from most expensive to least expensive
```
### Filters
Filter all presets based on their color, type or category. Must be done using JSON.stringify()
```javascript
const filters = {
    defaultColor: "Amarillo Patito",
    category: "premium"
}
const presets = await axios.get(`${baseURL}/?filters=${JSON.stringify(filters)}`) // This would return all premium presets that have a default color of Amarillo Patito
```